### PR TITLE
Fixed typo: writeline -> writeLine

### DIFF
--- a/lib/fastboot-app-server.js
+++ b/lib/fastboot-app-server.js
@@ -57,7 +57,7 @@ class FastBootAppServer {
         });
     }
 
-    this.ui.writeline(`using distPath; path=${this.distPath}`);
+    this.ui.writeLine(`using distPath; path=${this.distPath}`);
 
     return Promise.resolve();
   }


### PR DESCRIPTION
The server currently can't start when only using `distPath` (and not using `downloader`).

Thanks for your awesome work on Fastboot! Keep up the great work :)