### PR TITLE
Allow HTTP server customization with distPath from downloader

### DIFF
--- a/lib/fastboot-app-server.js
+++ b/lib/fastboot-app-server.js
@@ -15,6 +15,7 @@ class FastBootAppServer {
     this.notifier = options.notifier;
     this.cache = options.cache;
     this.ui = options.ui;
+    this.httpServer = options.httpServer;
 
     if (!this.ui) {
       let UI = require('./ui');
@@ -27,7 +28,8 @@ class FastBootAppServer {
       this.worker = new Worker({
         ui: this.ui,
         distPath: this.distPath || process.env.FASTBOOT_DIST_PATH,
-        cache: this.cache
+        cache: this.cache,
+        httpServer: this.httpServer
       });
 
       this.worker.start();
@@ -65,6 +67,7 @@ class FastBootAppServer {
     if (this.downloader) { this.downloader.ui = this.ui; }
     if (this.notifier) { this.notifier.ui = this.ui; }
     if (this.cache) { this.cache.ui = this.ui; }
+    if (this.httpServer) { this.httpServer.ui = this.ui; }
   }
 
   initializeApp() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -18,6 +18,10 @@ class Worker {
         cache: this.cache
       });
     }
+
+    if (!this.httpServer.cache) { this.httpServer.cache = this.cache; }
+    if (!this.httpServer.distPath) { this.httpServer.distPath = this.distPath; }
+    if (!this.httpServer.ui) { this.httpServer.ui = this.ui; }
   }
 
   start() {


### PR DESCRIPTION
This change allows users to specify a custom HTTP server when creating a FastBoot app server. It also ensures that the appropriate `cache`, `distPath`, `ui` properties are set on the custom server at the correct time. For example, `distPath` isn't set until the downloader has done its job.