### PR TITLE
Ensure `gzip` option is used.

### DIFF
--- a/src/fastboot-app-server.js
+++ b/src/fastboot-app-server.js
@@ -31,7 +31,7 @@ class FastBootAppServer {
         distPath: this.distPath || process.env.FASTBOOT_DIST_PATH,
         cache: this.cache,
         gzip: this.gzip,
-        httpServer: this.httpServer,
+        httpServer: this.httpServer
       });
 
       this.worker.start();

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,18 +11,19 @@ class Worker {
     this.ui = options.ui;
     this.cache = options.cache;
     this.gzip = options.gzip || false;
-    
+
     if (!this.httpServer) {
       this.httpServer = new ExpressHTTPServer({
         ui: this.ui,
         distPath: this.distPath,
-        cache: this.cache
+        cache: this.cache,
+        gzip: this.gzip
       });
     }
 
     if (!this.httpServer.cache) { this.httpServer.cache = this.cache; }
     if (!this.httpServer.distPath) { this.httpServer.distPath = this.distPath; }
-    if (!this.httpServer.ui) { this.httpServer.ui = this.ui; }    
+    if (!this.httpServer.ui) { this.httpServer.ui = this.ui; }
   }
 
   start() {


### PR DESCRIPTION
`gzip` option was introduced in a recent PR and was properly threaded
through from `fastboot-app-server.js` to `worker.js`, but when the
worker started its `express-http-server.js` it wasn't passed the `gzip`
option.  Ultimately, this meant that `gzip: true` had no effect.