### PR TITLE
404 handling under `/assets/`

### DIFF
--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -37,6 +37,10 @@ class ExpressHTTPServer {
     if (this.distPath) {
       app.get('/', middleware);
       app.use(express.static(this.distPath));
+      app.get('/assets/*', function(req, res) {
+        res.status(404);
+        res.send();
+      });
     }
 
     app.get('/*', middleware);


### PR DESCRIPTION
- send actual HTTP 404, do not execute FastBoot App