### PR TITLE
Make Express static serving configurable

### DIFF
--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -15,6 +15,7 @@ class ExpressHTTPServer {
     this.password = options.password;
     this.cache = options.cache;
     this.gzip = options.gzip || false;
+    this.staticAssetOptions = Object.assign({}, options.staticAssetOptions);
     this.beforeMiddleware = options.beforeMiddleware || noop;
     this.afterMiddleware = options.afterMiddleware || noop;
 
@@ -43,7 +44,7 @@ class ExpressHTTPServer {
 
     if (this.distPath) {
       app.get('/', fastbootMiddleware);
-      app.use(express.static(this.distPath));
+      app.use(express.static(this.distPath, this.staticAssetOptions));
       app.get('/assets/*', function(req, res) {
         res.sendStatus(404);
       });

--- a/src/fastboot-app-server.js
+++ b/src/fastboot-app-server.js
@@ -19,6 +19,7 @@ class FastBootAppServer {
     this.username = options.username;
     this.password = options.password;
     this.httpServer = options.httpServer;
+    this.staticAssetOptions = options.staticAssetOptions;
     this.beforeMiddleware = options.beforeMiddleware;
     this.afterMiddleware = options.afterMiddleware;
 
@@ -38,6 +39,7 @@ class FastBootAppServer {
         username: this.username,
         password: this.password,
         httpServer: this.httpServer,
+        staticAssetOptions: this.staticAssetOptions,
         beforeMiddleware: this.beforeMiddleware,
         afterMiddleware: this.afterMiddleware
       });

--- a/src/worker.js
+++ b/src/worker.js
@@ -13,6 +13,8 @@ class Worker {
     this.gzip = options.gzip;
     this.username = options.username;
     this.password = options.password;
+
+    this.staticAssetOptions = options.staticAssetOptions;
     this.beforeMiddleware = options.beforeMiddleware;
     this.afterMiddleware = options.afterMiddleware;
 
@@ -24,8 +26,9 @@ class Worker {
         gzip: this.gzip,
         username: this.username,
         password: this.password,
+        staticAssetOptions: this.staticAssetOptions,
         beforeMiddleware: this.beforeMiddleware,
-        afterMiddleware: this.afterMiddleware,
+        afterMiddleware: this.afterMiddleware
       });
     }
 

--- a/test/app-server-test.js
+++ b/test/app-server-test.js
@@ -56,6 +56,18 @@ describe("FastBootAppServer", function() {
       });
   });
 
+  it("serves static assets configurably", function () {
+    return runServer('custom-static-asset-options-app-server')
+      .then(() => request('http://localhost:3000/assets/fastboot-test.js'))
+      .then(response => {
+        expect(response.headers['cache-control']).to.equal('public, max-age=31536000');
+        expect(response.headers['x-test-path']).to.contain('assets/fastboot-test.js');
+        expect(JSON.parse(response.headers['x-test-stat'])).to.be.an('object');
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.contain('"use strict";');
+      });
+  });
+
   it("returns a 404 status code for non-existent assets",  function() {
     return runServer('basic-app-server')
       .then(() => request('http://localhost:3000/assets/404-does-not-exist.js'))

--- a/test/fixtures/custom-static-asset-options-app-server.js
+++ b/test/fixtures/custom-static-asset-options-app-server.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var path = require('path');
+var alchemistRequire = require('broccoli-module-alchemist/require');
+var FastBootAppServer = alchemistRequire('fastboot-app-server');
+
+var server = new FastBootAppServer({
+  distPath: path.resolve(__dirname, './basic-app'),
+  staticAssetOptions: {
+    maxAge: '3650d',
+    setHeaders: function (res, path, stat) {
+      res.set('x-test-path', path);
+      res.set('x-test-stat', JSON.stringify(stat));
+    }
+  }
+});
+
+server.start();


### PR DESCRIPTION
Express allows you to configure parameters when you serve static assets: https://expressjs.com/en/4x/api.html#express

For example, you can set `maxAge` on the request so the browser knows to cache the asset.

This PR allows these options to be made configurable.