### PR TITLE
Set the main entry point to the built commonjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fastboot-app-server",
   "version": "1.0.0-rc.5",
   "description": "A production-ready app server for running Ember FastBoot apps",
-  "main": "src/fastboot-app-server.js",
+  "main": "dist/cjs/fastboot-app-server.js",
   "scripts": {
     "prepublish": "ember build",
     "test": "ember build && NODE_ENV=test mocha"


### PR DESCRIPTION
It was never using the files in `dist/`. This change follows https://github.com/monegraph/broccoli-module-alchemist instructions and sets main to the built `dist/` file as the entry point.

In a way fixes https://github.com/ember-fastboot/fastboot-app-server/issues/38, except that by happenstance fastboot-app-server's main src files seem to be working under 4.2. But not https://github.com/ember-fastboot/fastboot or https://github.com/ember-fastboot/fastboot-express-middleware

Additionally it seems the reason why travis doesn't blow up during testing is because of `alchemistRequire` https://github.com/ember-fastboot/fastboot-app-server/blob/master/test/app-server-test.js#L7