### PR TITLE
[WIP] Add tests to replicate failure for afterMiddleware on success

### DIFF
--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -22,6 +22,7 @@ class ExpressHTTPServer {
   }
 
   serve(fastbootMiddleware) {
+
     let app = this.app;
     let username = this.username;
     let password = this.password;

--- a/test/app-server-test.js
+++ b/test/app-server-test.js
@@ -75,17 +75,26 @@ describe("FastBootAppServer", function() {
       .then(() => request('http://localhost:3000'))
       .then(response => {
         expect(response.statusCode).to.equal(418);
-        expect(response.headers['x-test-header']).to.equal('testing');
+        expect(response.headers['x-test-header']).to.equal('before-middleware-testing');
         expect(response.body).to.equal(JSON.stringify({ send: 'json back'}));
       });
   });
 
   it("executes afterMiddleware when there is an error", function() {
-    return runServer('after-middleware-server')
+    return runServer('after-middleware-server-broken')
       .then(() => request('http://localhost:3000'))
       .then(response => {
         expect(response.body).to.not.match(/error/);
-        expect(response.headers['x-test-header']).to.equal('testing');
+        expect(response.headers['x-test-header']).to.equal('after-middleware-testing');
+      });
+  });
+
+   it("executes afterMiddleware", function() {
+    return runServer('after-middleware-server')
+      .then(() => request('http://localhost:3000'))
+      .then(response => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers['x-test-header']).to.equal('after-middleware-testing');
       });
   });
 

--- a/test/fixtures/after-middleware-server-broken.js
+++ b/test/fixtures/after-middleware-server-broken.js
@@ -4,13 +4,13 @@ var path = require('path');
 var alchemistRequire = require('broccoli-module-alchemist/require');
 var FastBootAppServer = alchemistRequire('fastboot-app-server');
 
-function setXTestHeader(req, res, next) {
+function setXTestHeader(err, req, res, next) {
   res.set('x-test-header', 'after-middleware-testing')
   next();
 }
 
 var server = new FastBootAppServer({
-  distPath: path.resolve(__dirname, './basic-app'),
+  distPath: path.resolve(__dirname, './broken-app'),
   afterMiddleware: function (app) {
     app.use(setXTestHeader);
   },

--- a/test/fixtures/before-middleware-server.js
+++ b/test/fixtures/before-middleware-server.js
@@ -10,7 +10,7 @@ function setStatusCode418(req, res, next) {
 }
 
 function setXTestHeader(req, res, next) {
-  res.set('X-Test-Header', 'testing')
+  res.set('X-Test-Header', 'before-middleware-testing')
   next();
 }
 


### PR DESCRIPTION
This replicates the issue mentioned in #44. The afterMiddleware will be called whenever there's an error but not when the request is successful because of two reasons.

1. On failure, the afterMiddleware that includes [four arguments in the middleware acts as the error handler as per express](http://expressjs.com/en/guide/error-handling.html). So whenever there's a failure in the express router, this will be called.

2. On success, [the fastboot middleware doesn't call `next()`](https://github.com/ember-fastboot/fastboot-express-middleware/blob/master/src/index.js#L51) to invoke this middleware but finishes off with a `send()`. But then again the user must have configured the middleware with 3 arguments for the middleware to be invoked.

May be it makes more sense if the afterMiddleware gets separated into an error handler and an afterResponseHook. Users need to be educated that the afterResponseHook is useful only to run operations such as logging, do post request db operations and not meant to modify the response since with `send()` we're past that.


I started looking into this issue since @rwjblue suggested we can use the afterMiddleware hook to set the cache control headers for the assets folder content. It's 0 by default now. I've raised #52 for that.

If we can figure out a way forward, I can help land that.