### PR TITLE
Respond with 404 for forbidden assets

### DIFF
--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -17,6 +17,12 @@ class ExpressHTTPServer {
     this.gzip = options.gzip || false;
     this.beforeMiddleware = options.beforeMiddleware || noop;
     this.afterMiddleware = options.afterMiddleware || noop;
+    this.forbiddenAssets = [
+      '/fastbootAssetMap.json',
+      '/package.json',
+      '/node_modules/*',
+      '/fastboot/*'
+    ];
 
     this.app = express();
   }
@@ -43,6 +49,11 @@ class ExpressHTTPServer {
 
     if (this.distPath) {
       app.get('/', fastbootMiddleware);
+      this.forbiddenAssets.forEach(function(path) {
+        app.get(path, function(req, res) {
+          res.sendStatus(404);
+        });
+      });
       app.use(express.static(this.distPath));
       app.get('/assets/*', function(req, res) {
         res.sendStatus(404);

--- a/test/app-server-test.js
+++ b/test/app-server-test.js
@@ -70,6 +70,20 @@ describe("FastBootAppServer", function() {
       });
   });
 
+  it("returns a 404 status code for forbidden assets",  function() {
+    return runServer('basic-app-server')
+      .then(() => request('http://localhost:3000/package.json'))
+      .then(response => {
+        expect(response.statusCode).to.equal(404);
+        expect(response.body).to.match(/Not Found/);
+      })
+      .then(() => request('http://localhost:3000/'))
+      .then(response => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.contain('Welcome to Ember');
+      });
+  });
+
   it("executes beforeMiddleware", function() {
     return runServer('before-middleware-server')
       .then(() => request('http://localhost:3000'))


### PR DESCRIPTION
There are a number of internal files in the `dist` directory that are currently publicly exposed by the fastboot server (e.g. `dist/package.json`, `dist/node_modules/*`, etc).

Don't think there are any security concerns with these files being exposed, just not the expected behavior of the server and not particularly elegant.

This commit returns a 404 when a client requests any of the forbidden assets.