### PR TITLE
allow easy setting of host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ const FastBootAppServer = require('fastboot-app-server');
 
 let server = new FastBootAppServer({
   distPath: 'dist',
-  gzip: true // Optional - Enables gzip compression.
+  gzip: true, // Optional - Enables gzip compression.
+  host: '0.0.0.0', // Optional - Sets the host the server listens on.
+  port: 4000 // Optional - Sets the port the server listens on (defaults to the PORT env var or 3000).
 });
 
 server.start();

--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -15,6 +15,8 @@ class ExpressHTTPServer {
     this.password = options.password;
     this.cache = options.cache;
     this.gzip = options.gzip || false;
+    this.host = options.host;
+    this.port = options.port;
     this.beforeMiddleware = options.beforeMiddleware || noop;
     this.afterMiddleware = options.afterMiddleware || noop;
 
@@ -54,7 +56,7 @@ class ExpressHTTPServer {
     this.afterMiddleware(app);
 
     return new Promise(resolve => {
-      let listener = app.listen(process.env.PORT || 3000, () => {
+      let listener = app.listen(this.port || process.env.PORT || 3000, this.host || process.env.HOST, () => {
         let host = listener.address().address;
         let port = listener.address().port;
 

--- a/src/fastboot-app-server.js
+++ b/src/fastboot-app-server.js
@@ -16,6 +16,8 @@ class FastBootAppServer {
     this.cache = options.cache;
     this.ui = options.ui;
     this.gzip = options.gzip;
+    this.host = options.host;
+    this.port = options.port;
     this.username = options.username;
     this.password = options.password;
     this.httpServer = options.httpServer;
@@ -35,6 +37,8 @@ class FastBootAppServer {
         distPath: this.distPath || process.env.FASTBOOT_DIST_PATH,
         cache: this.cache,
         gzip: this.gzip,
+        host: this.host,
+        port: this.port,
         username: this.username,
         password: this.password,
         httpServer: this.httpServer,

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,6 +11,8 @@ class Worker {
     this.ui = options.ui;
     this.cache = options.cache;
     this.gzip = options.gzip;
+    this.host = options.host;
+    this.port = options.port;
     this.username = options.username;
     this.password = options.password;
     this.beforeMiddleware = options.beforeMiddleware;
@@ -22,6 +24,8 @@ class Worker {
         distPath: this.distPath,
         cache: this.cache,
         gzip: this.gzip,
+        host: this.host,
+        port: this.port,
         username: this.username,
         password: this.password,
         beforeMiddleware: this.beforeMiddleware,

--- a/test/app-server-test.js
+++ b/test/app-server-test.js
@@ -102,6 +102,15 @@ describe("FastBootAppServer", function() {
       });
   });
 
+  it("responds on the configured host and port", function() {
+    return runServer('ipv4-app-server')
+      .then(() => request('http://127.0.0.1:4100/'))
+      .then((response) => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.contain('Welcome to Ember');
+      });
+  });
+
 });
 
 function runServer(name) {

--- a/test/fixtures/ipv4-app-server.js
+++ b/test/fixtures/ipv4-app-server.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var path = require('path');
+const FastBootAppServer = require('../../src/fastboot-app-server');
+
+var server = new FastBootAppServer({
+  port: 4100,
+  host: '0.0.0.0',
+  distPath: path.resolve(__dirname, './basic-app')
+});
+
+server.start();


### PR DESCRIPTION
I'm aware #8 had been closed before but I'm not really sure what the downsides of making setting the host and port easy are. How things currently are, I'd have to subclass `ExpressHTTPServer` only to change the host and it doesn't really seem clear whether that should be used by anyone anyway (see discussion here: https://github.com/ember-fastboot/fastboot-app-server/pull/34#discussion_r91873431)

I think providing options for both `host` and `port` is even better than allowing env vars as its more flexible.