### PR TITLE
Add `app` option to express-http-server

### DIFF
--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -20,7 +20,7 @@ class ExpressHTTPServer {
     this.beforeMiddleware = options.beforeMiddleware || noop;
     this.afterMiddleware = options.afterMiddleware || noop;
 
-    this.app = express();
+    this.app = options.app || express();
   }
 
   serve(fastbootMiddleware) {


### PR DESCRIPTION
Allows easier construction and better separation of custom Express servers.