### PR TITLE
Named pipes support on Windows for fastboot for IISNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ let server = new FastBootAppServer({
   gzip: true, // Optional - Enables gzip compression.
   host: '0.0.0.0', // Optional - Sets the host the server listens on.
   port: 4000, // Optional - Sets the port the server listens on (defaults to the PORT env var or 3000).
+  path: '\\\\.\\pipe\\testpipe', // Optional - Sets the path to the named pipe or socket to use (specify this or port, not both). 
   sandboxGlobals: { GLOBAL_VALUE: MY_GLOBAL }, // Optional - Make values available to the Ember app running in the FastBoot server, e.g. "MY_GLOBAL" will be available as "GLOBAL_VALUE"
   chunkedResponse: true // Optional - Opt-in to chunked transfer encoding, transferring the head, body and potential shoeboxes in separate chunks. Chunked transfer encoding should have a positive effect in particular when the app transfers a lot of data in the shoebox.
 });
@@ -237,3 +238,16 @@ let server = new FastBootAppServer({
   password: 'zoey'
 });
 ```
+
+## Named pipes
+
+Some tools (in particular, `iisnode`) use local named pipes rather than TCP to 
+communicate to the HTTP server running in node. The pipe should be placed in 
+the `path` option rather than the `port` option (even though it arrives from 
+`iisnode` via `process.env.PORT`).
+
+When testing with pipes, node-based HTTP clients should supply the pipe in 
+the `socketPath` option of `http.request`. The `request` and `request-promise` 
+packages, often used because they simplify HTTP interaction, do not support a 
+socket path and hence cannot be used for named pipes. (This is one of the 
+outlying cases it simplified away.)

--- a/src/express-http-server.js
+++ b/src/express-http-server.js
@@ -17,6 +17,7 @@ class ExpressHTTPServer {
     this.gzip = options.gzip || false;
     this.host = options.host;
     this.port = options.port;
+    this.path = options.path;
     this.beforeMiddleware = options.beforeMiddleware || noop;
     this.afterMiddleware = options.afterMiddleware || noop;
 
@@ -56,14 +57,21 @@ class ExpressHTTPServer {
     this.afterMiddleware(app);
 
     return new Promise(resolve => {
-      let listener = app.listen(this.port || process.env.PORT || 3000, this.host || process.env.HOST, () => {
-        let host = listener.address().address;
-        let port = listener.address().port;
+      if (this.path) {
+        let listener = app.listen(this.path, () => {
+          this.ui.writeLine('HTTP server started on named pipe; path=%s', listener.address());
+          resolve();
+        });
+      } else {
+        let listener = app.listen(this.port || process.env.PORT || 3000, this.host || process.env.HOST, () => {
+          let host = listener.address().address;
+          let port = listener.address().port;
 
-        this.ui.writeLine('HTTP server started; url=http://%s:%s', host, port);
+          this.ui.writeLine('HTTP server started; url=http://%s:%s', host, port);
 
-        resolve();
-      });
+          resolve();
+        });
+      }
     });
   }
 

--- a/src/fastboot-app-server.js
+++ b/src/fastboot-app-server.js
@@ -18,6 +18,7 @@ class FastBootAppServer {
     this.gzip = options.gzip;
     this.host = options.host;
     this.port = options.port;
+    this.path = options.path;
     this.username = options.username;
     this.password = options.password;
     this.httpServer = options.httpServer;
@@ -41,6 +42,7 @@ class FastBootAppServer {
         gzip: this.gzip,
         host: this.host,
         port: this.port,
+        path: this.path,
         username: this.username,
         password: this.password,
         httpServer: this.httpServer,
@@ -56,6 +58,7 @@ class FastBootAppServer {
         (process.env.NODE_ENV === 'test' ? 1 : null) ||
         os.cpus().length;
 
+      assert(!(this.path && this.port), "FastBootAppServer must be provided with either an IPC path or a port option, but not both.");
       assert(this.distPath || this.downloader, "FastBootAppServer must be provided with either a distPath or a downloader option.");
       assert(!(this.distPath && this.downloader), "FastBootAppServer must be provided with either a distPath or a downloader option, but not both.");
     }

--- a/src/worker.js
+++ b/src/worker.js
@@ -13,6 +13,7 @@ class Worker {
     this.gzip = options.gzip;
     this.host = options.host;
     this.port = options.port;
+    this.path = options.path;
     this.username = options.username;
     this.password = options.password;
     this.beforeMiddleware = options.beforeMiddleware;
@@ -28,6 +29,7 @@ class Worker {
         gzip: this.gzip,
         host: this.host,
         port: this.port,
+        path: this.path,
         username: this.username,
         password: this.password,
         beforeMiddleware: this.beforeMiddleware,

--- a/src/worker.js
+++ b/src/worker.js
@@ -88,7 +88,11 @@ class Worker {
     this.ui.writeLine('starting HTTP server');
     return this.httpServer.serve(this.middleware)
       .then(() => {
-        process.send({ event: 'http-online' });
+        if (process.send) {
+          process.send({ event: 'http-online' });
+        } else {
+          process.emit('message', { event: 'http-online' });
+        }
       });
   }
 

--- a/test/app-server-test.js
+++ b/test/app-server-test.js
@@ -184,11 +184,15 @@ function httpIPCResponseData(response) {
 }
 
 function runServer(name) {
+  let options = {
+    silent: true
+  };
+  if (process.platform === "win32") { // Necessary for tests to run without timing out on Windows
+    options.execArgv = [];
+  }
   return new Promise((res, rej) => {
     let serverPath = path.join(__dirname, 'fixtures', `${name}.js`);
-    server = fork(serverPath, {
-      silent: true
-    });
+    server = fork(serverPath, options);
 
     server.on('error', rej);
 

--- a/test/fixtures/ipc-app-server.js
+++ b/test/fixtures/ipc-app-server.js
@@ -11,7 +11,8 @@ if (process.platform === "win32") {
 }
 var server = new FastBootAppServer({
   path: pipe,
-  distPath: path.resolve(__dirname, './basic-app')
+  distPath: path.resolve(__dirname, './basic-app'),
+  workerCount: -1
 });
 
 server.start();

--- a/test/fixtures/ipc-app-server.js
+++ b/test/fixtures/ipc-app-server.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var path = require('path');
+const FastBootAppServer = require('../../src/fastboot-app-server');
+
+var pipe = "";
+if (process.platform === "win32") {
+    pipe = '\\\\.\\pipe\\testpipe';
+} else {
+    pipe = 'test.pipe';
+}
+var server = new FastBootAppServer({
+  path: pipe,
+  distPath: path.resolve(__dirname, './basic-app')
+});
+
+server.start();


### PR DESCRIPTION
IISNode uses a named pipe to connect served node processes with the IIS web requests and responses. Node does not support connecting a named pipe to clusters of forked processes, which fastboot uses. Hence, fastboot, as it stands, cannot be used with IISNode or any other Windows layer using named pipes.

This PR uses the option { processCount:-1 } to place fastboot in a mode where, rather than forking a cluster of worker processes, a single worker runs within what would have been the parent process, . This *does* work with IISNode, and IISNode can be configured to spawn several instances of the single-process fastboot server to take advantage of multiple cores.