### PR TITLE
Expose `distPath` on `reload` event

### DIFF
--- a/src/fastboot-app-server.js
+++ b/src/fastboot-app-server.js
@@ -146,7 +146,7 @@ class FastBootAppServer {
   }
 
   reload() {
-    this.broadcast({ event: 'reload' });
+    this.broadcast({ event: 'reload', distPath: this.distPath });
   }
 
   forkWorkers() {

--- a/src/worker.js
+++ b/src/worker.js
@@ -59,7 +59,9 @@ class Worker {
   handleMessage(message) {
     switch (message.event) {
       case 'reload':
-        this.fastboot.reload();
+        this.distPath = message.distPath || this.distPath;
+        this.ui.writeLine('Reloading the application from distPath:', this.distPath);
+        this.fastboot.reload({ distPath: this.distPath });
         break;
       case 'error':
         this.error = message.error;

--- a/test/app-server-test.js
+++ b/test/app-server-test.js
@@ -119,6 +119,15 @@ describe("FastBootAppServer", function() {
         expect(response.body).to.contain('Welcome to Ember from MY GLOBAL!');
       });
   });
+
+  it("allows changing of distpath", function() {
+    return runServer('dist-path-change-server')
+      .then(() => request('http://localhost:3000/'))
+      .then((response) => {
+        expect(response.statusCode).to.equal(200);
+        expect(response.body).to.contain('Welcome to Ember from MY GLOBAL!');
+      });
+  });
 });
 
 function runServer(name) {

--- a/test/fixtures/basic-app/index.html
+++ b/test/fixtures/basic-app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>FastbootTest</title>
+    <title>FastbootTest - basic</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/test/fixtures/broken-app/index.html
+++ b/test/fixtures/broken-app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>FastbootTest</title>
+    <title>FastbootTest - broken</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/test/fixtures/dist-path-change-server.js
+++ b/test/fixtures/dist-path-change-server.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const path = require('path');
+const FastBootAppServer = require('../../src/fastboot-app-server');
+
+const MY_GLOBAL = 'MY GLOBAL';
+
+class DownloaderNotifier {
+  constructor(options) {
+    this.distPath = options.distPath;
+    this.subscriptions = [];
+  }
+
+  subscribe(handler) {
+    this.subscriptions.push(handler);
+    return Promise.resolve();
+  }
+
+  trigger() {
+    this.distPath = path.resolve(__dirname, './global-app');
+    this.subscriptions.forEach(handler => {
+      handler();
+    });
+  }
+
+  download() {
+    return Promise.resolve(this.distPath);
+  }
+}
+
+const connector = new DownloaderNotifier({
+  distPath: path.resolve(__dirname, './basic-app')
+});
+
+var server = new FastBootAppServer({
+  notifier: connector,
+  downloader: connector,
+  sandboxGlobals: { THE_GLOBAL: MY_GLOBAL }
+});
+
+const serverPromise = server.start();
+
+// Don't run this on worker threads.
+if (serverPromise) {
+  serverPromise.then(() => {
+    connector.trigger();
+  });
+}

--- a/test/fixtures/global-app/index.html
+++ b/test/fixtures/global-app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>FastbootTest</title>
+    <title>FastbootTest - global</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
This is the first step toward supporting a dynamically changed `distPath`. It does not address `express-http-server`'s issues, but it is an incremental improvement.