### PR TITLE
Bump fastboot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-  - "4"
+  - "stable"
   - "6"
+  - "8"
+  - "10"
 
 env:
   - CXX=g++-4.8 WORKER_COUNT=2

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "chalk": "^2.0.1",
     "compression": "^1.6.2",
     "express": "^4.13.3",
-    "fastboot": "^1.1.4-beta.1",
-    "fastboot-express-middleware": "^1.1.1",
+    "fastboot": "^2.0.0",
+    "fastboot-express-middleware": "^1.2.0",
     "fs-promise": "^2.0.3",
     "request": "^2.81.0"
   },


### PR DESCRIPTION
I have tested that bumping `fastboot` and `fastboot-express-middleware` fixes the issue I'm experiencing with `ember-fetch`, `fastboot-app-server` and `ember-data@3.9` reported here ember-fastboot/ember-cli-fastboot/issues/686.